### PR TITLE
refactor(install): streamline package manager setup

### DIFF
--- a/install.php
+++ b/install.php
@@ -21,10 +21,8 @@ class LaravelInstaller
     {
         $this->displayHeader();
 
-        // Initialize the package manager if needed
-        if (! is_dir('node_modules')) {
-            $this->setupPackageManager();
-        }
+        // Initialize the package manager
+        $this->setupPackageManager();
 
         // Install dependencies
         $this->installComposerDependencies();


### PR DESCRIPTION
This pull request simplifies the install() function in install.php by removing an unnecessary check for the node_modules directory and always initializing the package manager.
Motivation

Previously, the setupPackageManager() method was only called if the node_modules directory did not exist. However, this caused an issue in scenarios where the node_modules directory was already present (e.g., when dependencies had been manually installed beforehand).

In such cases, the packageManager property was never initialized, leading to a fatal error when runBuildAssets() or installNodeDependencies() attempted to access it later in the process.

Example of the error:

```
PHP Fatal error:  Uncaught Error: Typed property LaravelInstaller::$packageManager must not be accessed before initialization in C:\_code\php\my-app\install.php:117
Stack trace:
#0 C:\_code\php\my-app\install.php(36): LaravelInstaller->installNodeDependencies()
#1 C:\_code\php\my-app\install.php(212): LaravelInstaller->install()
#2 {main}
  thrown in C:\_code\php\my-app\install.php on line 117
```

Solution

To prevent this issue, the conditional check was removed, ensuring that setupPackageManager() is always called. This guarantees that the packageManager property is properly initialized regardless of whether node_modules already exists, avoiding runtime errors.